### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pytest=4.3.0
-allure-pytest=2.6.0
+pytest==4.3.0
+allure-pytest==2.6.0
 requests==2.21.0
 jsonschema==2.6.0
-psycopg2-binary=2.7.7
+psycopg2-binary==2.7.7


### PR DESCRIPTION
Fixed error in qa_tool setup command: ... Invalid requirement, parse error at "'=4.3.0'"