### PR TITLE
more print in postgres and reporter.step

### DIFF
--- a/qa_tool/libs/postgres_connector.py
+++ b/qa_tool/libs/postgres_connector.py
@@ -26,7 +26,9 @@ class PostgresConnector(object):
         # TODO: Maybe RealDictCursor -> NamedTupleCursor https://stackoverflow.com/questions/6739355/dictcursor-doesnt-seem-to-work-under-psycopg2
         cursor_factory = psycopg2.extras.RealDictCursor if as_dict else psycopg2.extras.DictCursor
         with reporter.step("Postgre SQL to host: {host}:{port}, db_name: {database}".format(**self._connection_dict)):
-            logging.info("SQL: %s" % sql)
+            msg = "SQL: %s" % sql
+            logging.info(msg)
+            print(msg)
             with self.driver.connect(**self._connection_dict) as conn:
                 cursor = conn.cursor(cursor_factory=cursor_factory)
                 try:
@@ -34,6 +36,7 @@ class PostgresConnector(object):
                     return cursor.fetchall()
                 except (self.driver.ProgrammingError, self.driver.OperationalError) as e:
                     logging.error(e)
+            reporter.attach('DB Query', msg)
 
     def insert(self, table_name, dict_to_insert):
         """ WARNING! All strings passed unescaped """

--- a/qa_tool/libs/reporter.py
+++ b/qa_tool/libs/reporter.py
@@ -13,8 +13,10 @@ class Reporter(object):
     def step(self, step_text, step_prefix=None):
         if step_prefix is None:
             step_prefix = 'Step'
-        logging.info(step_prefix + f": {step_text}")
-        return allure.step(step_text)
+        msg = step_prefix + f": {step_text}"
+        logging.info(msg)
+        print(msg)
+        return allure.step(msg)
 
     def attach(self, title, body, type_=TEXT):
         body = str(body)


### PR DESCRIPTION
Можно сделать слегка по-другому.

в репортера вкрутить то, что ниже и везде в qa тулах его применять

```
def print(self, msg, log_lvl='info'):
  if os.getenv('USE_LOG', True):
    getattr(log, log_lvl)(msg)
  else:
    print(msg)
```